### PR TITLE
don't process bib URL fields

### DIFF
--- a/chapters/parsons/bibliography.bib
+++ b/chapters/parsons/bibliography.bib
@@ -64,9 +64,9 @@ year = {2022}
    publisher = {American Chemical Society},
    title = {Understanding the Electric Double-Layer Structure, Capacitance, and Charging Dynamics},
    volume = {122},
-   url = {https://pubs.acs.org/doi/10.1021/acs.chemrev.2c00097},
    year = {2022},
 }
+%   url = {https://pubs.acs.org/doi/10.1021/acs.chemrev.2c00097},
 
 %   author = {José J. López-García and José Horno and Constantino Grosse},
 @article{LopezGarciaHornoGrosse2018,
@@ -82,9 +82,9 @@ year = {2022}
    publisher = {Multidisciplinary Digital Publishing Institute},
    title = {Numerical Solution of the Electrokinetic Equations for Multi-ionic Electrolytes Including Different Ionic Size Related Effects},
    volume = {9},
-   url = {https://www.mdpi.com/2072-666X/9/12/647},
    year = {2018},
 }
+%   url = {https://www.mdpi.com/2072-666X/9/12/647},
 
 @article{GrayStiles2018,
    abstract = {The description of a conducting medium in thermal equilibrium, such as an electrolyte solution or a plasma, involves nonlinear electrostatics, a subject rarely discussed in the standard electricity and magnetism textbooks. We consider in detail the case of the electrostatic double layer formed by an electrolyte solution near a uniformly charged wall, and we use mean-field or Poisson-Boltzmann (PB) theory to calculate the mean electrostatic potential and the mean ion concentrations, as functions of distance from the wall. PB theory is developed from the Gibbs variational principle for thermal equilibrium of minimising the system free energy. We clarify the key issue of which free energy (Helmholtz, Gibbs, grand, ...) should be used in the Gibbs principle; this turns out to depend not only on the specified conditions in the bulk electrolyte solution (e.g. fixed volume or fixed pressure), but also on the specified surface conditions, such as fixed surface charge or fixed surface potential. Despite its nonlinearity the PB equation for the mean electrostatic potential can be solved analytically for planar or wall geometry, and we present analytic solutions for both a full electrolyte and for an ionic solution containing only counterions, i.e. ions of sign opposite to that of the wall charge. This latter case has some novel features. We also use the free energy to discuss the inter-wall forces which arise when the two parallel charged walls are sufficiently close to permit their double layers to overlap. We consider situations where the two walls carry equal charges, and where they carry equal and opposite charges.},
@@ -99,9 +99,9 @@ year = {2022}
    publisher = {IOP Publishing},
    title = {Nonlinear electrostatics: the {Poisson-Boltzmann} equation},
    volume = {39},
-   url = {https://iopscience.iop.org/article/10.1088/1361-6404/aaca5a},
    year = {2018},
 }
+%   url = {https://iopscience.iop.org/article/10.1088/1361-6404/aaca5a},
 
 @inbook{DagmawiParsons2024,
    abstract = {Here, we address the impact that steric models, introducing finite ion size effects, have on the contact angle for charged surfaces. We review the two most common steric models, namely the excluded volume (commonly referred to as the Bikerman model) and the Carnahan-Starling (CS) models. We clarify the thermodynamics of the solid–liquid electrolyte interface and show that the common case of an electrolyte reservoir characterized by bulk ion concentrations corresponds to the thermodynamics of the grand potential with fixed ionic chemical potentials. The grand potential gives distinctly different interfacial energies compared to the free energy, which corresponds to a finite number of ions in an electrolyte solution (relevant in nanofluidics, for instance). Steric models may be applied to either thermodynamic scenario, and applications to electrowetting are shown under the grand potential (large droplets with a bulk reservoir in the center). When sufficiently large potentials are applied to conducting electrodes, the steric models, unlike the classical point charge model, introduce ion specificity into the electrowetting contact angle via finite ion sizes, which introduces an asymmetry in the contact angle at positive and negative potentials. For electrowetting on dielectrics (EWOD), the theoretical contact angles match experimental values well until electrode potentials of 240V, with CS performing better than Bikerman. We hypothesize that contact angle saturation at 240V may arise due to a switch in the thermodynamics of the solid–liquid interfacial energy from grand potential (bulk reservoir) to free energy (finite ion number) conditions, capping the formation of a counterion adsorption layer at the electrode surface.},
@@ -115,9 +115,9 @@ year = {2022}
    publisher = {Elsevier},
    title = {Thermodynamics beyond dilute solution theory: Steric effects and electrowetting},
    volume = {1-3},
-   url = {https://linkinghub.elsevier.com/retrieve/pii/B9780323856690001379},
    year = {2024},
 }
+%   url = {https://linkinghub.elsevier.com/retrieve/pii/B9780323856690001379},
 
 @article{ParsonsSalis2019,
    abstract = {We resolve a thermodynamic inconsistency in previous theoretical descriptions of the free energy of chemisorption (charge regulation) under conditions where nonelectrostatic physisorption is included, as applied to surface forces and particle-particle interactions. We clarify the role of nonelectrostatic ion physisorption energies and show that a term previously thought to represent physisorbed ion concentrations (activities) should instead be interpreted as a "partial ion activity" based solely on the electrostatic physisorption energy and bulk concentration, or alternatively on the nonelectrostatic physisorption energy and surface concentration. Second, the chemisorption energy must be understood as the change in chemical potential after subtracting the electrostatic energy, not subtracting the physisorption energy. Consequently, a previously reported specific ion nonelectrostatic physisorption contribution to the chemisorption free energy is annulled. We also report a correction to the calculation of surface charge. The distinction in "partial ion activity" evaluated from bulk concentration or from surface concentration opens a way to study nonequilibrium forces where chemisorption is in equilibrium with physisorbed ions but not in equilibrium with bulk ions, e.g., by a jump in ion concentrations.},
@@ -132,9 +132,9 @@ year = {2022}
    publisher = {AIP Publishing LLC},
    title = {A thermodynamic correction to the theory of competitive chemisorption of ions at surface sites with nonelectrostatic physisorption},
    volume = {151},
-   url = {http://aip.scitation.org/doi/10.1063/1.5096237 https://aip.scitation.org/doi/abs/10.1063/1.5096237 /aip/jcp/article/151/2/024701/197866/A-thermodynamic-correction-to-the-theory-of https://pubs.aip.org/jcp/article/151/2/024701/197866/A-thermodynamic-correc},
    year = {2019},
 }
+%   url = {http://aip.scitation.org/doi/10.1063/1.5096237 https://aip.scitation.org/doi/abs/10.1063/1.5096237 /aip/jcp/article/151/2/024701/197866/A-thermodynamic-correction-to-the-theory-of https://pubs.aip.org/jcp/article/151/2/024701/197866/A-thermodynamic-correc},
 
 @article{ParsonsCarucciSalis2022,
    abstract = {Buffer solutions do not simply regulate pH, but also change the properties of protein molecules.},
@@ -149,9 +149,9 @@ year = {2022}
    publisher = {The Royal Society of Chemistry},
    title = {Buffer-specific effects arise from ionic dispersion forces},
    volume = {24},
-   url = {https://xlink.rsc.org/?DOI=D2CP00223J},
    year = {2022},
 }
+%   url = {https://xlink.rsc.org/?DOI=D2CP00223J},
 
 @article{CarnahanStarling1969,
    abstract = {A new equation of state for rigid spheres has been developed from an analysis of the reduced virial series. Comparisons with existing equations show that the new formula possesses superior ability to describe rigid-sphere behavior.},
@@ -165,9 +165,9 @@ year = {2022}
    publisher = {AIP Publishing},
    title = {Equation of State for Nonattracting Rigid Spheres},
    volume = {51},
-   url = {https://pubs.aip.org/jcp/article/51/2/635/456845/Equation-of-State-for-Nonattracting-Rigid-Spheres},
    year = {1969},
 }
+%   url = {https://pubs.aip.org/jcp/article/51/2/635/456845/Equation-of-State-for-Nonattracting-Rigid-Spheres},
 
 @article{MansooriCarnahanStarlingLeland1971,
    abstract = {An equation of state is proposed for the mixture of hard spheres based on an averaging process over the two results of the solution of the Percus–Yevick integral equation for the mixture of hard spheres. Compressibility and other equilibrium properties of the binary mixtures of hard spheres are calculated and they are compared with the related machine-calculated (Monte Carlo and molecular dynamics) data. The comparison shows excellent agreement between the proposed equation of state and the machine-calculated data.},
@@ -182,9 +182,9 @@ year = {2022}
    publisher = {AIP Publishing},
    title = {Equilibrium Thermodynamic Properties of the Mixture of Hard Spheres},
    volume = {54},
-   url = {https://pubs.aip.org/jcp/article/54/4/1523/445610/Equilibrium-Thermodynamic-Properties-of-the},
    year = {1971},
 }
+%   url = {https://pubs.aip.org/jcp/article/54/4/1523/445610/Equilibrium-Thermodynamic-Properties-of-the},
 
 @article{ParsonsNinham2009,
    abstract = {Ab initio molar volumes are calculated and used to derive radii for ions and neutral molecules using a spatially diffuse model of the electron distribution with Gaussian spread. The Gaussian radii obtained can be used for computation of nonelectrostatic ion-ion dispersion forces that underlie Hofmeister specific ion effects. Equivalent hard-sphere radii are also derived, and these are in reasonable agreement with crystalline ionic radii. The Born electrostatic self-energy is derived for a Gaussian model of the electronic charge distribution. It is shown that the ionic volumes used in electrostatic calculations of strongly hydrated cosmotropic ions ought best to include the first hydration shell. Ionic volumes for weakly hydrated chaotropic metal cations should exclude electron overlap (in electrostatic calculations). Spherical radii are calculated as well as nonisotropic ellipsoidal radii for nonspherical ions, via their nonisotropic static polarizability tensors.},
@@ -213,9 +213,9 @@ year = {2022}
    publisher = {Springer Berlin Heidelberg},
    title = {Homotopy Analysis Method in Nonlinear Differential Equations},
    volume = {9783642251320},
-   url = {https://link.springer.com/10.1007/978-3-642-25132-0},
    year = {2012},
 }
+%   url = {https://link.springer.com/10.1007/978-3-642-25132-0},
 
 @misc{PETSc_manual,
    abstract = {This manual describes the use of the Portable, Extensible Toolkit for Scientific Computation (PETSc) and the Toolkit for Advanced Optimization (TAO) for the numerical solution of partial differential equations and related problems on high-performance computers. PETSc/TAO is a suite of data structures and routines that provide the building blocks for the implementation of large-scale application codes on parallel (and serial) computers. PETSc uses the MPI standard for all distributed memory communication.},
@@ -226,9 +226,9 @@ year = {2022}
    keywords = {mathematics and computing},
    month = {11},
    title = {{PETSc/TAO Users Manual (Rev. 3.20)}},
-   url = {https://www.osti.gov/servlets/purl/2205494/},
    year = {2023},
 }
+%   url = {https://www.osti.gov/servlets/purl/2205494/},
 
 @article{petsc4py_2011,
    abstract = {This work presents two software components aimed to relieve the costs of accessing high-performance parallel computing resources within a Python programming environment: MPI for Python and PETSc for Python. MPI for Python is a general-purpose Python package that provides bindings for the Message Passing Interface (MPI) standard using any back-end MPI implementation. Its facilities allow parallel Python programs to easily exploit multiple processors using the message passing paradigm. PETSc for Python provides access to the Portable, Extensible Toolkit for Scientific Computation (PETSc) libraries. Its facilities allow sequential and parallel Python applications to exploit state of the art algorithms and data structures readily available in PETSc for the solution of large-scale problems in science and engineering.MPI for Python and PETSc for Python are fully integrated to PETSc-FEM, an MPI and PETSc based parallel, multiphysics, finite elements code developed at CIMEC laboratory. This software infrastructure supports research activities related to simulation of fluid flows with applications ranging from the design of microfluidic devices for biochemical analysis to modeling of large-scale stream/aquifer interactions. © 2011 Elsevier Ltd.},
@@ -243,9 +243,9 @@ year = {2022}
    publisher = {Elsevier},
    title = {Parallel distributed computing using {Python}},
    volume = {34},
-   url = {https://linkinghub.elsevier.com/retrieve/pii/S0309170811000777},
    year = {2011},
 }
+%   url = {https://linkinghub.elsevier.com/retrieve/pii/S0309170811000777},
 
 
 @article{MUMPS_2001,
@@ -261,9 +261,9 @@ year = {2022}
    publisher = {Society for Industrial and Applied Mathematics},
    title = {A Fully Asynchronous Multifrontal Solver Using Distributed Dynamic Scheduling},
    volume = {23},
-   url = {http://epubs.siam.org/doi/10.1137/S0895479899358194},
    year = {2001},
 }
+%   url = {http://epubs.siam.org/doi/10.1137/S0895479899358194},
 
 
 @article{MUMPS_2019,
@@ -279,9 +279,9 @@ year = {2022}
    publisher = {ACMPUB27New York, NY, USA},
    title = {Performance and Scalability of the Block Low-Rank Multifrontal Factorization on Multicore Architectures},
    volume = {45},
-   url = {https://dl.acm.org/doi/10.1145/3242094},
    year = {2019},
 }
+%   url = {https://dl.acm.org/doi/10.1145/3242094},
 
 @book{allgower1990numerical,
   abstract = {Over the past fifteen years two new techniques have yielded extremely important contributions toward the numerical solution of nonlinear systems of equations. This book provides an introduction to and an up-to-date survey of numerical continuation methods (tracing of implicitly defined curves) of both predictor-corrector and piecewise-linear types. It presents and analyzes implementations aimed at applications to the computation of zero points, fixed points, nonlinear eigenvalue problems, bifurcation and turning points, and economic equilibria. Many algorithms are presented in a pseudo code format. An appendix supplies five sample FORTRAN programs with numerical examples, which readers can adapt to fit their purposes, and a description of the program package SCOUT for analyzing nonlinear problems via piecewise-linear methods. An extensive up-to-date bibliography spanning 46 pages is included. The material in this book has been presented to students of mathematics, engineering and sciences with great success, and will also serve as a valuable tool for researchers in the field.},
@@ -300,10 +300,10 @@ year = {2022}
   series = {Springer Series in Computational Mathematics},
   timestamp = {2023-11-07T00:43:54.000+0100},
   title = {Numerical Continuation Methods: An Introduction},
-  url = {https://link.springer.com/book/10.1007/978-3-642-61257-2},
   volume = 13,
   year = 1990
 }
+%  url = {https://link.springer.com/book/10.1007/978-3-642-61257-2},
 
 
 # covariance matrix used by scipy.optimize.curve_fit
@@ -321,6 +321,6 @@ year = {2022}
    publisher = {John Wiley & Sons, Ltd},
    title = {Confidence region estimation techniques for nonlinear regression in groundwater flow: Three case studies},
    volume = {43},
-   url = {https://agupubs.onlinelibrary.wiley.com/doi/10.1029/2005WR004804},
    year = {2007},
 }
+%   url = {https://agupubs.onlinelibrary.wiley.com/doi/10.1029/2005WR004804},


### PR DESCRIPTION
The BibTeX style processes url fields even if a doi is provided,
generating redundant (and often ugly) url links in the bibliography.
    
Hide the URL fields in the bib file to block this.
